### PR TITLE
Remove redundant Transform wrapper

### DIFF
--- a/lib/src/home/home_page.dart
+++ b/lib/src/home/home_page.dart
@@ -71,10 +71,7 @@ class _HomePageState extends State<HomePage>
                           else
                             controller.reverse();
                         },
-                        child: Transform.translate(
-                          offset: Offset(0, cardAnimation.value),
-                          child: CardListWidget(),
-                        ),
+                        child: CardListWidget(),
                       ),
                       builder: (context, child) {
                         return Transform.translate(


### PR DESCRIPTION
## Summary
- eliminate redundant Transform widget in `HomePage`

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685df2a54a3883228b966ab77300774e